### PR TITLE
Upgrade pouchdb to 6.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "passport": "^0.3.2",
     "passport-http-bearer-sl": "^1.0.1",
     "passport-local": "^1.0.0",
-    "pouchdb": "~5.3.1",
+    "pouchdb": "6.4.3",
     "pouchdb-seed-design": "^0.2.0",
     "redis": "^2.5.2",
     "sofa-model": "^0.2.0",


### PR DESCRIPTION
Bump SuperLogin's PouchDB dependency up to version `6.4.3` from `~5.3.1`.

This greatly simplifies our AWS installs by using an "AWS-buildable" version of PouchDB's dependency on the "Leveldown" package.

Note: this will also match our other PouchDB version dependencies.